### PR TITLE
Updated links to working, some markdown cleaning

### DIFF
--- a/Intro.md
+++ b/Intro.md
@@ -80,7 +80,7 @@ computer.
  √    Have competency in the English language.  
   
  √    Have read the [Saylor Student
-Handbook](https://resources.saylor.org/wwwresources/archived/site/wp-content/uploads/2012/05/Saylor-StudentHandbook.pdf).  
+Handbook](https://www.saylor.org/handbook/).  
   
   √    Have completed and passed [POLSC221: Introduction to Comparative
 Politics](http://www.saylor.org/courses/polsc221/).

--- a/Unit01.md
+++ b/Unit01.md
@@ -10,17 +10,18 @@ have made in the development of modern international law.*
 **Unit 1 Time Advisory**  
 <span class="Apple-style-span">This unit will take you approximately 14
 hours to complete.   
-  
- ☐    Subunit 1.1: 3 hours  
-  
- ☐    Subunit 1.2: 4 hours  
-  
- ☐    Subunit 1.3: 3 hours</span>  
-  
- <span class="Apple-style-span">☐    Subunit 1.4: 4 hours</span>
 
-**Unit1 Learning Outcomes**  
-Upon successful completion of this unit, the student will be able to:  
+ ☐    Subunit 1.1: 3 hours  
+
+ ☐    Subunit 1.2: 4 hours  
+
+ ☐    Subunit 1.3: 3 hours  
+
+ ☐    Subunit 1.4: 4 hours </span>
+
+**Unit 1 Learning Outcomes**  
+Upon successful completion of this unit, the student will be able to:
+  
 -   Define international law.
 -   Explain how international law is established and enforced.
 -   Identify legal issues present in modern international disputes.
@@ -65,7 +66,7 @@ financial transactions, sovereignty, and immunity.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Benedict Kingsbury’s “[What, How, and Who Should Public
     International Law Regulate? New Problems of Global Administrative
-    Governance](https://web.archive.org/web/20131015141525/http://untreaty.un.org/cod/avl/ls/Kingsbury_IL.html)”
+    Governance](https://legal.un.org/avl/ls/Kingsbury_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the
@@ -79,7 +80,7 @@ financial transactions, sovereignty, and immunity.*
     International Law?”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Christian Tomuschat’s “[What is General International
-    Law](https://web.archive.org/web/20131017193453/http://legal.un.org/avl/ls/Tomuschat.html)?”
+    Law](https://legal.un.org/avl/ls/Tomuschat_IL.html)?”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the
@@ -97,7 +98,7 @@ warfare began to evolve in Western civilization, spurring debates
 between utilitarian and humanitarian leaders as to how war should be
 conducted and what, if any, limits should be placed on military conduct
 during operations.  As commerce and military conquests became more
-frequent, alliances and treaties were formed. *
+frequent, alliances and treaties were formed.*
 
 -   **Web Media: The United Nations’ Audiovisual Library of
     International Law: Mónica Pinto’s “The Evolution of International
@@ -105,7 +106,7 @@ frequent, alliances and treaties were formed. *
     Link: The United Nations’ Audiovisual Library of International Law:
     Mónica Pinto’s “[The Evolution of International Society and
     International
-    Law](https://web.archive.org/web/20131015140743/http://untreaty.un.org/cod/avl/ls/Pinto_IL.html)”
+    Law](https://legal.un.org/avl/ls/Pinto_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the
@@ -120,7 +121,7 @@ frequent, alliances and treaties were formed. *
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge A. A. Cançado Trindade’s “[Jus Cogens in Contemporary
     International
-    Law](http://untreaty.un.org/cod/avl/ls/Cancado-Trindade_IL.html)”
+    Law](https://legal.un.org/avl/ls/Cancado-Trindade_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the heading
@@ -134,8 +135,8 @@ frequent, alliances and treaties were formed. *
     International Law: Anthony D’Amato’s “Customary International Law”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Anthony D’Amato’s “[Customary International
-    Law](http://untreaty.un.org/cod/avl/ls/D-Amato_IL.html)”
-    (RealPlayer)  
+    Law](https://legal.un.org/avl/ls/D-Amato_IL.html)”
+    (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the “Customary
     International Law” heading.  Please watch the video presentation (31
@@ -150,27 +151,26 @@ custom, precedent, treaty, statute, and constitution.  In this subunit,
 you will read about the sources of international law and how they are
 applied by courts, tribunals, agencies, and peacekeeping forces.*
 
--   **Reading: The United Nations’ Audiovisual Library of International
+-   **Web Media: The United Nations’ Audiovisual Library of International
     Law: Christopher Greenwood’s “Sources of International Law: An
     Introduction”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Christopher Greenwood’s “[Sources of International Law: An
-    Introduction](https://web.archive.org/web/20131015140730/http://untreaty.un.org/cod/avl/ls/Greenwood_IL.html)”
-    (PDF)  
+    Introduction](https://legal.un.org/avl/ls/Greenwood_IL.html)”
+    (RealPlayer Video)  
         
-     Instructions: Go to the linked page and click the tab for “Related
-    Material,” and then on the link under “The Sources of International
-    Law” to read the article.  
+     Instructions: Click on the link titled "Video" under the heading
+    “The Sources of International Law.” Please watch the video
+    presentation (42 mins.).  
         
      Terms of Use: Please respect the copyright and terms of use
     displayed on the webpages above.
 
--   **Web Media: The United Nations’ Audiovisual Library of
-    International Law: Anthony D’Amato’s “The Sources of International
-    Law”**
+-   **Web Media: The United Nations’ Audiovisual Library of International
+    Law: Anthony D’Amato’s “The Sources of International Law”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Anthony D’Amato’s “[The Sources of International
-    Law](https://web.archive.org/web/20131015140857/http://untreaty.un.org/cod/avl/ls/D-Amato_IL.html)”
+    Law](https://legal.un.org/avl/ls/D-Amato_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the heading
@@ -186,7 +186,7 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge A. A. Cançado Trindade ‘s “[General Principles of Law as a
     Source of International
-    Law](https://web.archive.org/web/20131015141136/http://untreaty.un.org/cod/avl/ls/Cancado-Trindade_IL.html)”
+    Law](https://legal.un.org/avl/ls/Cancado-Trindade_IL.html)”
     (RealPlayer)  
         
      Instructions: Please go to the linked page and scroll down the page
@@ -198,12 +198,13 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
     displayed on the webpages above.
 
 **1.4 Enforcement of International Law** <span id="1.4"></span> 
+
 -   **Web Media: The United Nations’ Audiovisual Library of
     International Law: Georges Abi-Saab’s “The International Judicial
     Function”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Georges Abi-Saab’s “[The International Judicial
-    Function](https://web.archive.org/web/20131015135629/http://untreaty.un.org/cod/avl/ls/Abi-Saab_CT.html)”
+    Function](https://legal.un.org/avl/ls/Abi-Saab_CT.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the
@@ -216,7 +217,7 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
     International Law**
     Link: The United Nations’ Documentation Research Guide:
     *[International
-    Law](http://www.un.org/depts/dhl/resguide/specil.htm)* (HTML)  
+    Law](https://research.un.org/en/docs/law/introduction)* (HTML)  
         
      Instructions: Please go to the linked page and read it to learn
     about the various international courts and tribunals that seek to
@@ -231,10 +232,10 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Vera Gowlland-Debbas’ lecture notes on “[The International Court of
     Justice as the Principal Judicial Organ of the United
-    Nations](https://web.archive.org/web/20131109214604/http://untreaty.un.org/cod/avl/ls/Gowlland-Debbas_CT.html)”
+    Nations](https://legal.un.org/avl/pdf/ls/Gowlland-Debbas_outline.pdf)”
     (PDF)  
         
-     Instructions: Go to the linked page and clickthe tab for “Related
+     Instructions: Go to the linked page and click the tab for “Related
     Material,” and then on the PDF icon link next to “Outline of
     Lecture” to read the lecture notes.  
         
@@ -247,7 +248,7 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Vera Gowlland-Debbas’ “[The International Court of Justice as the
     Principal Judicial Organ of the United
-    Nations](http://untreaty.un.org/cod/avl/ls/Gowlland-Debbas_CT.html)”
+    Nations](https://legal.un.org/avl/ls/Gowlland-Debbas_CT.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the
@@ -261,7 +262,7 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
     Criminal Court at a Glance”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Sang Hyun Song’s “[The International Criminal Court at a
-    Glance](http://untreaty.un.org/cod/avl/ls/Song_CLP.html)”
+    Glance](https://legal.un.org/avl/ls/Song_CLP.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “English” under the
@@ -277,7 +278,7 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge A. A. Cançado Trindade’s “[The Access of Individuals to
     International
-    Justice](https://web.archive.org/web/20131015140135/http://untreaty.un.org/cod/avl/ls/Cancado-Trindade_HR.html)”
+    Justice](https://legal.un.org/avl/ls/Cancado-Trindade_HR.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the “Access of
@@ -286,5 +287,3 @@ applied by courts, tribunals, agencies, and peacekeeping forces.*
         
      Terms of Use: Please respect the copyright and terms of use
     displayed on the webpages above.
-
-

--- a/Unit02.md
+++ b/Unit02.md
@@ -37,6 +37,7 @@ This unit will take you approximately 6 hours to complete. 
 
 **Unit2 Learning Outcomes**  
 Upon successful completion of this unit, the student will be able to:  
+
 -   Define realist, liberal, and constructivist political theories.
 -   Explain the application and impact of realist, liberal, and
     constructivist theories to international law.
@@ -79,7 +80,7 @@ Security Council for action.*
 
 -   **Reading: United Nations: “UN at a Glance”**
     Link: United Nations: “[UN at a
-    Glance](http://www.un.org/en/aboutun/index.shtml)” (HTML)  
+    Glance](https://web.archive.org/web/20160205034737/http://www.un.org/en/about-un/index.html)” (HTML)  
         
      Instructions: Please go to the linked page and read the article,
     which discusses the formation of the United Nations and explains its
@@ -90,7 +91,7 @@ Security Council for action.*
 
 -   **Reading: United Nations: “Main Bodies”**
     Link: United Nations: “[Main
-    Bodies](http://www.un.org/en/mainbodies/)” (HTML)  
+    Bodies](https://www.un.org/en/about-us/main-bodies)” (HTML)  
         
      Instructions: Go to the linked page and read the article, which
     discusses main bodies  of the United Nations, such as the Security
@@ -105,9 +106,9 @@ Security Council for action.*
     Contradictory Commitments in International Law”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Emmanuel Roucounas’ “[Successive, Parallel and Contradictory
-    Commitments](http://untreaty.un.org/cod/avl/ls/Roucounas_IL.html)[in
+    Commitments in
     International
-    Law](http://untreaty.un.org/cod/avl/ls/Roucounas_IL.html)”
+    Law](https://legal.un.org/avl/ls/Roucounas_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the
@@ -124,7 +125,7 @@ explore how power impacts modern international law.*
 -   **Reading: IR Theory.com: Mark Beavis’ “IR Paradigms, Approaches and
     Theories”**
     Link: IR Theory.com: Mark Beavis’ “[IR Paradigms, Approaches and
-    Theories](http://www.irtheory.com/know.htm)” (HTML)  
+    Theories](https://web.archive.org/web/20191130001720/http://irtheory.com/know.htm)” (HTML)  
         
      Instructions: Please review this summary of the international
     relations and power relationships.  
@@ -138,7 +139,7 @@ explore how power impacts modern international law.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Yasuaki Onuma’s “[International Law in a Multi-Polar and
     Multi-Civilizational World of the 21st
-    Century](https://web.archive.org/web/20131109205152/http://untreaty.un.org/cod/avl/ls/Onuma_IL.html)”
+    Century](https://legal.un.org/avl/ls/Onuma_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the
@@ -159,8 +160,8 @@ that culture has on international law.*
     Contemporary International Law Making”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Edward McWhinney’s Lecture Notes on “[Multiculturalism and
-    Contemporary](http://untreaty.un.org/cod/avl/ls/McWhinney_IL.html)[International
-    LawMaking](http://untreaty.un.org/cod/avl/ls/McWhinney_IL.html)”
+    Contemporary International
+    Law Making](https://legal.un.org/avl/ls/McWhinney_IL.html)”
     (PDF)  
         
      Instructions: Click on the “Related Materials” tab and then click
@@ -175,7 +176,7 @@ that culture has on international law.*
     Contemporary International Law Making”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Edward McWhinney’s “[Multiculturalism and Contemporary International
-    Law Making](http://untreaty.un.org/cod/avl/ls/McWhinney_IL.html)”
+    Law Making](https://legal.un.org/avl/ls/McWhinney_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the

--- a/Unit03.md
+++ b/Unit03.md
@@ -1,5 +1,6 @@
-**Unit 3: Territory and Sovereignty** <span id="3"></span>  **Unit 3
-Time Advisory**  
+**Unit 3: Territory and Sovereignty** <span id="3"></span>
+
+**Unit 3 Time Advisory**  
 This unit will take you approximately 10 hours to complete.   
   
  ☐    Subunit 3.1: 3 hours  
@@ -8,10 +9,11 @@ This unit will take you approximately 10 hours to complete. 
   
  ☐    Subunit 3.3: 2 hours 
 
-**Unit3 Learning Outcomes**  
-Upon successful completion of this unit, the student will be able to:  
+**Unit 3 Learning Outcomes**  
+Upon successful completion of this unit, the student will be able to:
+  
 -   Explain the application and impact of international law to
-    territorial boundaries and diplomatic missions.
+    territorial boundaries and diplomatic missions. 
 -   Explain how international laws are enforced on the world’s oceans.
 -   Assess the effectiveness of strategies used throughout history to
     deal with piracy on the high seas.
@@ -35,7 +37,7 @@ mitigate these types of conflicts.*
     Malcolm Shaw’s Lecture Notes on “[International Legal Principles
     Relating to Territorial Disputes (The Rules Governing the
     Acquisition of Title to
-    Territory)](http://untreaty.un.org/cod/avl/ls/Shaw_BD.html)” (PDF)  
+    Territory)](https://legal.un.org/avl/ls/Shaw_BD.html)” (PDF)  
         
      Instructions: Click on the “Related Materials” tab and then click
     to download the “Outline of Lecture” under the “International Legal
@@ -53,9 +55,9 @@ mitigate these types of conflicts.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Malcolm Shaw’s “[International Legal Principles Relating to
     Territorial Disputes (The Rules Governing the Acquisition of Title
-    to Territory](http://untreaty.un.org/cod/avl/ls/Shaw_BD.html))”
-    (RealPlayerVideo)  
-        
+    to Territory)](https://legal.un.org/avl/ls/Shaw_BD.html)”
+    (RealPlayer Video)  
+
      Instructions: Click on the link titled “Video” under the
     “International Legal Principles Relating to Territorial Disputes”
     tab.  Please watch the video presentation (48 mins.).  
@@ -68,7 +70,7 @@ mitigate these types of conflicts.*
     Disputes”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Malcolm Shaw’s Lecture Notes on “[Settling Territorial
-    Disputes](http://untreaty.un.org/cod/avl/ls/Shaw_BD.html)” (PDF)  
+    Disputes](https://legal.un.org/avl/ls/Shaw_BD.html)” (PDF)  
         
      Instructions: Click on the “Related Materials” tab and then click
     to download the “Outline of Lecture” under the “Settling Territorial
@@ -82,7 +84,7 @@ mitigate these types of conflicts.*
     International Law: Malcolm Shaw’s “Settling Territorial Disputes”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Malcolm Shaw’s “[Settling Territorial
-    Disputes](http://untreaty.un.org/cod/avl/ls/Shaw_BD.html)”
+    Disputes](https://legal.un.org/avl/ls/Shaw_BD.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the “Settling
@@ -102,7 +104,7 @@ piracy on the high seas.*
     the Sea”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Tullio Treves’ “[United Nations Convention on the Law of the
-    Sea](http://untreaty.un.org/cod/avl/ls/Treves_LS.html)” (PDF)  
+    Sea](https://legal.un.org/avl/ls/Treves_LS.html)” (PDF)  
         
      Instructions: Click on the “Related Materials” tab and then click
     to download the file titled “United Nations Convention on the Law of
@@ -118,7 +120,7 @@ piracy on the high seas.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Tullio Treves’ Lecture Notes on “[The New Law of the Sea and
     the Settlement of
-    Disputes](https://web.archive.org/web/20130715023826/http://untreaty.un.org/cod/avl/ls/Treves_LS.html)”
+    Disputes](https://legal.un.org/avl/ls/Treves_LS.html)”
     (PDF)  
         
      Instructions: Click on the “Related Materials” tab and then click
@@ -134,7 +136,7 @@ piracy on the high seas.*
     the Settlement of Disputes”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Tullio Treves’ “[The New Law of the Sea and the Settlement of
-    Disputes](http://untreaty.un.org/cod/avl/ls/Treves_LS.html)” 
+    Disputes](https://legal.un.org/avl/ls/Treves_LS.html)” 
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “English” in the middle of
@@ -148,7 +150,7 @@ piracy on the high seas.*
     Delimitation”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Malcolm Shaw’s Lecture Notes on “[Principles of Maritime
-    Delimitation](https://web.archive.org/web/20131015135616/http://untreaty.un.org/cod/avl/ls/Shaw_BD.html)”
+    Delimitation](https://legal.un.org/avl/ls/Shaw_BD.html)”
     (PDF)  
         
      Instructions: Click on the “Related Materials” tab and then click
@@ -163,7 +165,7 @@ piracy on the high seas.*
     Delimitation”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Malcolm Shaw’s “[Principles of Maritime
-    Delimitation](http://untreaty.un.org/cod/avl/ls/Shaw_BD.html)”
+    Delimitation](https://legal.un.org/avl/ls/Shaw_BD.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “English” under the
@@ -178,7 +180,7 @@ piracy on the high seas.*
     the Law of the Sea”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Helmut Tuerk’s “[The Landlocked States and the Law of the
-    Sea](http://untreaty.un.org/cod/avl/ls/Tuerk_LOS.html)” (RealPlayer
+    Sea](https://legal.un.org/avl/ls/Tuerk_LOS.html)” (RealPlayer
     Video)  
         
      Instructions: Click on the link titled “Video” under the
@@ -194,7 +196,7 @@ piracy on the high seas.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Helmut Tuerk’s “[The Resurgence of Piracy: A Phenomenon of
     Modern
-    Times](https://web.archive.org/web/20130616035841/http://untreaty.un.org/cod/avl/ls/Tuerk_LOS.html)” 
+    Times](https://legal.un.org/avl/ls/Tuerk_LOS.html)” 
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” under the “A
@@ -229,7 +231,7 @@ missions and military forces.*
     International Law: John Dugard’s “Diplomatic Protection”**
     Link: The United Nations’ Audiovisual Library of International Law:
     John Dugard’s “[Diplomatic
-    Protection](https://web.archive.org/web/20131027060405/http://untreaty.un.org/cod/avl/ls/Dugard_DP.html)”
+    Protection](https://legal.un.org/avl/ls/Dugard_DP.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the

--- a/Unit04.md
+++ b/Unit04.md
@@ -8,8 +8,9 @@ This unit will take you approximately 12 hours to complete. 
   
  ☐    Subunit 4.3: 5 hours 
 
-**Unit4 Learning Outcomes**  
-Upon successful completion of this unit, the student will be able to:  
+**Unit 4 Learning Outcomes**  
+Upon successful completion of this unit, the student will be able to:
+  
 -   Explain limitations on lawful deployment of military forces and the
     use of nuclear, biological, and chemical weapons.
 -   Identify political, ethical, and legal issues incident to the use of
@@ -49,7 +50,7 @@ of combatants and non-combatants, were developed.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Adam Roberts’ “[The Equal Application of the Laws of War: A
     Principle Under
-    Pressure](https://web.archive.org/web/20131015141334/http://untreaty.un.org/cod/avl/ls/Roberts_LAC.html)”
+    Pressure](https://legal.un.org/avl/ls/Roberts_LAC.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the link titled “Video” in the middle of the
@@ -83,7 +84,7 @@ preemptive war under international law.*
     Reconsideration”**
     Link: Strategic Studies Institute: Dr. Colin S. Gray’s “[The
     Implications of Preemptive and Preventive War Doctrines: A
-    Reconsideration”](http://www.strategicstudiesinstitute.army.mil/pubs/display.cfm?pubID=789)
+    Reconsideration](https://ssi.armywarcollege.edu/2007/pubs/the-implications-of-preemptive-and-preventive-war-doctrines-a-reconsideration/)"
     (PDF)  
         
      Instructions: Please go to the linked page, then download and read
@@ -103,7 +104,7 @@ weapons.*
     “Weapons of Mass Destruction and International Law”**
     Link: American Society of International Law: David P. Fidler’s
     “[Weapons of Mass Destruction and International
-    Law](https://web.archive.org/web/20130722164326/http://www.asil.org/insigh97.cfm)”
+    Law](https://www.asil.org/insights/volume/8/issue/3/weapons-mass-destruction-and-international-law)”
     (HTML)  
         
      Instructions: Please go to the linked page and read the article,
@@ -118,7 +119,7 @@ weapons.*
     Law, Security, and Weapons of Mass Destruction”**
     Link: The United Nations: Jayantha Dhanapala’s “[International Law,
     Security, and Weapons of Mass
-    Destruction”](http://lcnp.org/disarmament/Speeches/dhanapalasabaspeech.htm)
+    Destruction](https://web.archive.org/web/20160306011543/http://lcnp.org/disarmament/Speeches/dhanapalasabaspeech.htm)"
     (HTML)  
         
      Instructions: Please go to the linked page and read the article,
@@ -131,14 +132,9 @@ weapons.*
 
 -   **Web Media: The United Nations’ Audiovisual Library of
     International Law: Mahasiko Asada’s “Nuclear Weapons and
-    International Law (Part I) and (Part II): Non-Proliferation of
-    Nuclear Weapons”**
+    International Law” Parts 1 & 2**
     Link: The United Nations’ Audiovisual Library of International Law:
-    Mahasiko Asada’s “Nuclear Weapons and International Law ([Part
-    I](http://webcast.un.org/ramgen/ondemand/legal/video/LectureSeries/asada100602.rm))
-    and ([Part
-    II](http://webcast.un.org/ramgen/ondemand/legal/video/LectureSeries/asada100602_2.rm)): Non-Proliferation
-    of Nuclear Weapons” (RealPlayer Video)  
+    Mahasiko Asada’s “[Nuclear Weapons and International Law](https://legal.un.org/avl/ls/Asada_ACD.html)" (RealPlayer Video)  
         
      Instructions: Please watch the video presentations (33 and 35
     mins.).  
@@ -151,7 +147,7 @@ weapons.*
     Convention: An Overview”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Santiago Oñate Laborde’s “[The Chemical Weapons Convention: An
-    Overview](https://web.archive.org/web/20131017032735/http://legal.un.org/avl/ls/Onate-Laborde_AC.html)”
+    Overview](https://legal.un.org/avl/ls/Onate-Laborde_AC.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (58 mins.).  

--- a/Unit05.md
+++ b/Unit05.md
@@ -8,8 +8,9 @@ This unit will take you approximately 13 hours to complete. 
   
  ☐    Subunit 5.3: 4 hours
 
-**Unit5 Learning Outcomes**  
+**Unit 5 Learning Outcomes**  
 Upon successful completion of this unit, the student will be able to:  
+
 -   Explain how war crimes, genocide, and crimes against humanity are
     defined and enforced in international law.
 -   Discuss the difficulties of enforcing crimes that occur across
@@ -39,7 +40,7 @@ sovereignty.*
 -   **Reading: American Society of International Law: Gail A. Partin’s
     “International Criminal Law”**
     Link: American Society of International Law: Gail A. Partin’s
-    “[International Criminal Law](http://www.asil.org/erg/?page=icl)”
+    “[International Criminal Law](https://web.archive.org/web/20110806071831/http://www.asil.org/erg/?page=icl)”
     (HTML)  
         
      Instructions: Please go to the linked page and read the article,
@@ -53,13 +54,9 @@ sovereignty.*
 
 -   **Web Media: The United Nations’ Audiovisual Library of
     International Law: Benjamin B. Ferencz’s “The Evolution of
-    International Criminal Law (Part I) and (Part II)”**
+    International Criminal Law (Part I and II)”**
     Link: The United Nations’ Audiovisual Library of International Law:
-    Benjamin B. Ferencz’s “The Evolution of International Criminal Law
-    ([Part
-    I](http://webcast.un.org/ramgen/ondemand/legal/video/LectureSeries/ferencz071119-1.rm))
-    and ([Part
-    II](http://webcast.un.org/ramgen/ondemand/legal/video/LectureSeries/ferencz071114-2.rm))”
+    Benjamin B. Ferencz’s “[The Evolution of International Criminal Law](https://legal.un.org/avl/ls/Ferencz_CLP.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentations (33 and 28
@@ -89,7 +86,7 @@ sovereignty.*
     International Criminal Justice”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Justice Richard Goldstone’s “[The Future of International Criminal
-    Justice](http://untreaty.un.org/cod/avl/ls/Goldstone_CLP.html)” 
+    Justice](https://legal.un.org/avl/ls/Goldstone_CLP.html)” 
     (RealPlayer Video)  
         
      Instructions: Click on the “Video” link in the middle of the page. 
@@ -99,16 +96,16 @@ sovereignty.*
     displayed on the webpages above.
 
 **5.2 War Crimes and Genocide** <span id="5.2"></span> 
+
 -   **Reading: The United Nations’ Audiovisual Library of International
     Law: William A. Schabas’ “Convention on the Prevention and
     Punishment of the Crime of Genocide”**
     Link: The United Nations’ Audiovisual Library of International Law:
     William A. Schabas’ “[Convention on the Prevention and Punishment of
     the Crime of
-    Genocide](https://web.archive.org/web/20131017022408/http://legal.un.org/avl/ha/cppcg/cppcg.html)”
-    (HTMLor PDF)  
-        
-     Instructions: Please go to the linked page and read Dr. Schabas’
+    Genocide](https://web.archive.org/web/20131017022408/http://legal.un.org/avl/ha/cppcg/cppcg.html)” (HTML or PDF)
+    
+    Instructions: Please go to the linked page and read Dr. Schabas’
     article on the prevention and punishment of genocide.  You can
     access a PDF version by selecting the “English” link.  
         
@@ -116,11 +113,9 @@ sovereignty.*
     displayed on the webpages above.
 
 -   **Reading: The United Nations’ Audiovisual Library of International
-    Law: William A. Schabas’ Lecture Notes on “Genocide: The Crime of
-    Crimes”**
+    Law: William A. Schabas’ Lecture Notes on “Genocide and International Law”**
     Link: The United Nations’ Audiovisual Library of International Law:
-    William A. Schabas’ Lecture Notes on “[Genocide: Crime of
-    Crimes](https://web.archive.org/web/20131015140139/http://untreaty.un.org/cod/avl/ls/Schabas_CLP.html)”
+    William A. Schabas’ Lecture Notes on “[Genocide and International Law](https://legal.un.org/avl/ls/Schabas_CLP.html)”
     (PDF)  
         
      Instructions: Click on the “Related Materials” tab and download the
@@ -135,7 +130,7 @@ sovereignty.*
     Law”**
     Link: The United Nations’ Audiovisual Library of International Law:
     William A. Schabas’ “[Genocide and International
-    Law](http://untreaty.un.org/cod/avl/ls/Schabas_CLP.html)”
+    Law](https://legal.un.org/avl/ls/Schabas_CLP.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the “Video” link in the middle of the page. 
@@ -151,7 +146,7 @@ sovereignty.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Theodor Meron’s “[Reflections on the Prosecution of War Crimes
     by International Tribunals: A Historical
-    Perspective](https://web.archive.org/web/20131109213411/http://untreaty.un.org/cod/avl/ls/Meron_CLP.html)”
+    Perspective](https://legal.un.org/avl/ls/Meron_CLP.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the “Video” tab in the middle of the page. 
@@ -161,6 +156,7 @@ sovereignty.*
     displayed on the webpages above.
 
 **5.3 Terrorism** <span id="5.3"></span> 
+
 -   **Reading: The United Nations’ Audiovisual Library of International
     Law: Rohan Perera’s “Declaration on Measures to Eliminate
     International Terrorism (1994)”**
@@ -168,7 +164,7 @@ sovereignty.*
     Rohan Perera’s “[Declaration on Measures to Eliminate International
     Terrorism
     (1994)”](https://web.archive.org/web/20131002091922/http://untreaty.un.org/cod/avl/ha/dot/dot.html)
-    (HTMLor PDF)  
+    (HTML or PDF)  
         
      Instructions: Please go to the linked page and read Dr. Perera’s
     article on UN measures enacted in 1994 to eliminate international
@@ -200,7 +196,7 @@ sovereignty.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Pierre Klein’s “[International Convention for the Suppression of the
     Financing of
-    Terrorism](http://untreaty.un.org/cod/avl/ha/icsft/icsft.html)”
+    Terrorism](https://web.archive.org/web/20131005155220/http://untreaty.un.org/cod/avl/ha/icsft/icsft.html)”
     (PDF)  
         
      Instructions: Please go to the linked pageand select the link

--- a/Unit06.md
+++ b/Unit06.md
@@ -8,8 +8,9 @@ This unit will take you approximately 10 hours to complete. 
   
  ☐    Subunit 6.3: 2 hours 
 
-**Unit6 Learning Outcomes**  
+**Unit 6 Learning Outcomes**  
 Upon successful completion of this unit, the student will be able to:  
+
 -   Explain the roles of the WTO and UNCITRAL in regulating
     international trade.
 -   Discuss international treaties and laws that seek to regulate trade.
@@ -47,7 +48,7 @@ and the role that it plays in regulating international trade. *
 -   **Reading: World Trade Organization: “10 Benefits of the WTO Trading
     System”**
     Link: World Trade Organization: “[10 Benefits of the WTO Trading
-    System](http://www.wto.org/english/thewto_e/whatis_e/10ben_e/10b00_e.htm)”
+    System](https://web.archive.org/web/20120305225759/http://www.wto.org/english/thewto_e/whatis_e/10ben_e/10b00_e.htm)”
     (HTML or PDF)  
         
      Instructions: Please go to the linked page and read the article,
@@ -62,7 +63,7 @@ and the role that it plays in regulating international trade. *
     about the WTO”**
     Link: World Trade Organization: “[10 Common Misunderstandings about
     the
-    WTO](http://www.wto.org/english/thewto_e/whatis_e/10mis_e/10m00_e.htm)”
+    WTO](https://web.archive.org/web/20120305225759/http://www.wto.org/english/thewto_e/whatis_e/10mis_e/10m00_e.htm)”
     (HTML or PDF)  
         
      Instructions: Please go to the linked page and read the article,
@@ -98,7 +99,7 @@ and the role that it plays in regulating international trade. *
     Gabrielle Marceau’s “[The General Basic Legal Principles that
     Underpin the International Trading System (The Basic Legal
     Principles of the
-    WTO)”](http://untreaty.un.org/cod/avl/ls/Marceau_IEL.html)
+    WTO)”](https://legal.un.org/avl/ls/Marceau_IEL.html)
     (RealPlayer Video)  
         
      Instructions: Click on the “Video” link in the middle of the page. 
@@ -113,7 +114,7 @@ and the role that it plays in regulating international trade. *
     Link: The United Nations’ Audiovisual Library of International Law:
     Pascal Lamy’s “[The Relationship between WTO Law and General
     International
-    Law](https://web.archive.org/web/20131015135929/http://untreaty.un.org/cod/avl/ls/Lamy_IEL.html)”
+    Law](https://legal.un.org/avl/ls/Lamy_IEL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the “Video” link in the middle of the page. 
@@ -132,7 +133,7 @@ international trade.*
     United Nations Commission on International Trade Law**
     Link: United Nations: *[The UNCITRAL Guide: Basic Facts about the
     United Nations Commission on International Trade
-    Law](http://www.uncitral.org/uncitral/en/about_us.html)* (PDF)  
+    Law](https://uncitral.un.org/en/about)* (PDF)  
         
      Instructions: Click on the link titled “The UNCITRAL Guide.” 
     Please read the article, which explains the role of the UNCITRAL in
@@ -148,7 +149,7 @@ international trade.*
     Link: The United Nations’ Audiovisual Library of International Law:
     Jernej Sekolec’s “[The Role of UNCITRAL in the Harmonization and the
     Modernization of the Law of International
-    Trade](https://web.archive.org/web/20131015135603/http://untreaty.un.org/cod/avl/ls/Sekolec_IEL.html)”
+    Trade](https://legal.un.org/avl/ls/Sekolec_IEL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the “Video” link under the “UNCITRAL”
@@ -159,12 +160,13 @@ international trade.*
 
 **6.3 Additional International Laws Pertaining to Commerce and
 Business** <span id="6.3"></span> 
+
 -   **Web Media: The United Nations’ Audiovisual Library of
     International Law: Anne Trebilcock’s “The Development of
     International Labour Law”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Anne Trebilcock’s “[The Development of International Labour
-    Law](https://web.archive.org/web/20131015140055/http://untreaty.un.org/cod/avl/ls/Trebilcock_ILL.html)”
+    Law](https://legal.un.org/avl/ls/Trebilcock_ILL.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (47 mins.).  
@@ -178,7 +180,7 @@ Business** <span id="6.3"></span> 
     Link: The United Nations’ Audiovisual Library of International Law:
     W. Michael Reisman’s “[Foreign Investment, Economic Development and
     National
-    Sovereignty](https://web.archive.org/web/20131015140051/http://untreaty.un.org/cod/avl/ls/Reisman_IEL.html)”
+    Sovereignty](https://legal.un.org/avl/ls/Reisman_IEL.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (51 mins.).  

--- a/Unit07.md
+++ b/Unit07.md
@@ -6,8 +6,9 @@ This unit will take you approximately 9 hours to complete. 
   
  ☐    Subunit 7.2: 5 hours 
 
-**Unit7 Learning Outcomes**  
-Upon successful completion of this unit, the student will be able to:  
+**Unit 7 Learning Outcomes**  
+Upon successful completion of this unit, the student will be able to:
+  
 -   Describe international organizations with jurisdiction over
     environmental law.
 -   Identify threats to the environment that are regulated by
@@ -17,6 +18,7 @@ Upon successful completion of this unit, the student will be able to:
 
 **7.1 An Introduction to International Environmental Law** <span
 id="7.1"></span> 
+
 -   **Reading: Center for International Environmental Law: Marcos A.
     Orellana’s “Climate Change and the Millenium Goals: The Right To
     Development, International Cooperation and the Clean Development
@@ -24,7 +26,7 @@ id="7.1"></span> 
     Link: Center for International Environmental Law: Marcos A.
     Orellana’s “[Climate Change and the Millenium Goals: The Right To
     Development, International Cooperation and the Clean Development
-    Mechanism](http://www.ciel.org/Publications/pubccp.html)” (PDF)  
+    Mechanism](https://web.archive.org/web/20110815125800/https://www.ciel.org/Publications/pubccp.html)” (PDF)  
         
      Instructions: Please go to the linked page and scroll down until
     you see the link for “Climate Change and the Millenium Goals: The
@@ -38,7 +40,7 @@ id="7.1"></span> 
 
 -   **Reading: Ecovitality.org: “Causes of Environmental Law Failures”**
     Link: Ecovitality.org: “[Causes of Environmental Law
-    Failures](http://ecovitality.org/badlaw.htm)” (HTML)  
+    Failures](https://web.archive.org/web/20120711132926/https://ecovitality.org/badlaw.htm)” (HTML)  
         
      Instructions: Please go to the linked page and read the article.  
         
@@ -50,7 +52,7 @@ id="7.1"></span> 
     Law—An Introduction”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Edith Brown Weiss’ “[International Environmental Law—An
-    Introduction](https://web.archive.org/web/20131109211018/http://untreaty.un.org/cod/avl/ls/Weiss_EL.html)”
+    Introduction](https://legal.un.org/avl/ls/Weiss_EL.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the “English” link under the “International
@@ -63,7 +65,7 @@ id="7.1"></span> 
 -   **Web Media: Judge Hanqin Xue ‘s “Transboundary Damage in
     International Law”**
     Link: Judge Hanqin Xue ‘s “[Transboundary Damage in International
-    Law](http://webcast.un.org/ramgen/ondemand/legal/video/LectureSeries/xue100520.rm)”
+    Law](https://legal.un.org/avl/ls/Xue_EL.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (48 mins.).  
@@ -79,7 +81,7 @@ id="7.2"></span> 
     Link: Center for International Environmental Law: Anne Perrault and
     Joanna Levitt’s “[Using International Law and Institutions to
     Protect Children’s Environmental
-    Health](http://www.ciel.org/Publications/pubhre.html)” (PDF)  
+    Health](https://web.archive.org/web/20111106081326/http://www.ciel.org/Publications/pubhre.html)” (PDF)  
         
      Instructions: Go to the linked page and scroll down until you see
     the link for “Using International Law and Institutions to Protect
@@ -96,7 +98,7 @@ id="7.2"></span> 
     Link: The United Nations’ Audiovisual Library of International Law:
     Nico Schrijver’s “[International Law in the Field of Sustainable
     Development—Evolution, Meaning and
-    Status](https://web.archive.org/web/20131015135528/http://untreaty.un.org/cod/avl/ls/Schrijver_D.html)”
+    Status](https://legal.un.org/avl/ls/Schrijver_D.html)”
     (RealPlayer Video)  
         
      Instructions: Click on the “English” link under the “Development”
@@ -110,7 +112,7 @@ id="7.2"></span> 
     Infectious Disease Control”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Gian Luca Burci’s “[International Law and Infectious Disease
-    Control](https://web.archive.org/web/20131015135701/http://untreaty.un.org/cod/avl/ls/Burci_HS.html)”
+    Control](https://legal.un.org/avl/ls/Burci_HS.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (47 mins.).  
@@ -123,7 +125,7 @@ id="7.2"></span> 
     of Biotechnology”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Matthias Herdegen’s “[The International Regulation of
-    Biotechnology](https://web.archive.org/web/20131015140024/http://untreaty.un.org/cod/avl/ls/Herdegen_HS.html)”
+    Biotechnology](https://legal.un.org/avl/ls/Herdegen_HS.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (27 mins.).  

--- a/Unit08.md
+++ b/Unit08.md
@@ -9,8 +9,9 @@ This unit will take you approximately 7 hours to complete. 
   
  ☐    Subunit 8.2: 5 hours 
 
-**Unit8 Learning Outcomes**  
+**Unit 8 Learning Outcomes**  
 Upon successful completion of this unit, the student will be able to:  
+
 -   Explain how international organizations seek to protect and regulate
     global legal interests in the Arctic and Space.
 -   Identify international laws and treaties that govern activities in
@@ -21,13 +22,11 @@ Upon successful completion of this unit, the student will be able to:
 
 **8.1 International Laws Pertaining to the Arctic** <span
 id="8.1"></span> 
+
 -   **Reading: The United Nations’ Audiovisual Library of International
-    Law: Donald McRae’s Lecture Notes on “Legal Status of the Arctic:
-    Some Contemporary Issues”**
+    Law: Donald McRae’s Lecture Notes on “Selected Issues Relating to the Arctic”**
     Link: The United Nations’ Audiovisual Library of International Law:
-    Donald McRae’s Lecture Notes on “[Legal Status of the Arctic: Some
-    Contemporary
-    Issues](https://web.archive.org/web/20131015140203/http://untreaty.un.org/cod/avl/ls/McRae_A.html)”
+    Donald McRae’s Lecture Notes on “[Selected Issues Relating to the Arctic](https://legal.un.org/avl/ls/McRae_A.html)”
     (PDF)  
         
      Instructions: Click on the “Related Materials” tab and download the
@@ -38,11 +37,9 @@ id="8.1"></span> 
     displayed on the webpages above.
 
 -   **Web Media: The United Nations’ Audiovisual Library of
-    International Law: Donald McRae’s “Legal Status of the Arctic: Some
-    Contemporary Issues”**
+    International Law: Donald McRae’s “Selected Issues Relating to the Arctic”**
     Link: The United Nations’ Audiovisual Library of International Law:
-    Donald McRae’s “[Legal Status of the Arctic: Some Contemporary
-    Issues](http://untreaty.un.org/cod/avl/ls/McRae_A.html)” (RealPlayer
+    Donald McRae’s “[Selected Issues Relating to the Arctic](https://legal.un.org/avl/ls/McRae_A.html)” (RealPlayer
     Video)  
         
      Instructions: Please watch the video presentation (58 mins.).  
@@ -51,6 +48,7 @@ id="8.1"></span> 
     displayed on the webpages above.
 
 **8.2 International Laws Pertaining to Space** <span id="8.2"></span> 
+
 -   **Reading: United Nations: Detlev Wolter’s “Common Security in Outer
     Space and International Law”**
     Link: United Nations: Detlev Wolter’s “[Common Security in Outer
@@ -70,7 +68,7 @@ id="8.1"></span> 
     Link: The United Nations’ Audiovisual Library of International Law:
     Vladimír Kopal’s “[The Progressive Development of International
     Space Law by the United
-    Nations”](https://web.archive.org/web/20131109202518/http://untreaty.un.org/cod/avl/ls/Kopal_LOS.html)
+    Nations”](https://legal.un.org/avl/ls/Kopal_LOS.html)
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation by choosing the
@@ -86,7 +84,7 @@ id="8.1"></span> 
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Vladlen Stepanovich Vereshchetin’s “[The Law of Outer Space in
     the General Legal Field (Commonality and
-    Particularities)”](https://web.archive.org/web/20131015140947/http://untreaty.un.org/cod/avl/ls/Vereshchetin_LOS.html)
+    Particularities)”](https://legal.un.org/avl/ls/Vereshchetin_LOS.html)
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (63 mins.).  

--- a/Unit09.md
+++ b/Unit09.md
@@ -6,8 +6,9 @@ This unit will take you approximately 9 hours to complete. 
   
  ☐    Subunit 9.2: 4 hours 
 
-**Unit9 Learning Outcomes**  
+**Unit 9 Learning Outcomes**  
 Upon successful completion of this unit, the student will be able to:  
+
 -   Define universal human rights under international law.
 -   Explain strategies for implementation and enforcement of universal
     human rights and non-discrimination under international law.
@@ -15,6 +16,7 @@ Upon successful completion of this unit, the student will be able to:
     international law.
 
 **9.1 International Human Rights Laws** <span id="9.1"></span> 
+
 -   **Reading: Stanford University: “Human Rights”**
     Link: Stanford University: “[Human
     Rights](http://plato.stanford.edu/entries/rights-human/)” (HTML)  
@@ -30,7 +32,7 @@ Upon successful completion of this unit, the student will be able to:
     Human Rights”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Antônio Augusto Cançado Trindade’s “[Universal Declaration of Human
-    Rights](https://web.archive.org/web/20131206211049/http://untreaty.un.org/cod/avl/ha/udhr/udhr.html)”
+    Rights](https://legal.un.org/avl/ha/udhr/udhr.html)”
     (HTML or PDF)  
         
      Instructions: Please go to the linked page and read Judge
@@ -47,7 +49,7 @@ Upon successful completion of this unit, the student will be able to:
     Link: The United Nations’ Audiovisual Library of International Law:
     Judge Thomas Buergenthal’s “[A Brief History of International Human
     Rights
-    Law](https://web.archive.org/web/20131015140019/http://untreaty.un.org/cod/avl/ls/Buergenthal_HR.html)”
+    Law](https://legal.un.org/avl/ls/Buergenthal_HR.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (33 mins.).  
@@ -60,7 +62,7 @@ Upon successful completion of this unit, the student will be able to:
     Enforcement”**
     Link: The United Nations’ Audiovisual Library of International Law:
     Anthony D’Amato’s “[Human Rights and
-    Enforcement](https://web.archive.org/web/20131015140101/http://untreaty.un.org/cod/avl/ls/D-Amato_HR.html)”
+    Enforcement](https://legal.un.org/avl/ls/D-Amato_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (31 mins.).  
@@ -76,7 +78,7 @@ Upon successful completion of this unit, the student will be able to:
     Menachem Mautner ‘s “[How Should a Liberal State Treat Non-Liberal
     Cultural Groups? The Jurisprudence of Human Rights and the Standard
     of Human
-    Dignity](https://web.archive.org/web/20131015141228/http://untreaty.un.org/cod/avl/ls/Mautner_IL.html)”
+    Dignity](https://legal.un.org/avl/ls/Mautner_IL.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (29 mins.).  
@@ -85,6 +87,7 @@ Upon successful completion of this unit, the student will be able to:
     displayed on the webpages above.
 
 **9.2 International Anti-Discrimination Laws** <span id="9.2"></span> 
+
 -   **Reading: United Nations: Convention on the Elimination of all
     Forms of Discrimination Against Women (CEDAW)**
     Link: United Nations: [Convention on the Elimination of all Forms of
@@ -105,7 +108,7 @@ Upon successful completion of this unit, the student will be able to:
     Linos-Alexander Sicilianos’ “[The Application of the United Nations
     Convention on the Elimination of All Forms of Racial Discrimination:
     Challenges
-    Ahead](https://web.archive.org/web/20131015140033/http://untreaty.un.org/cod/avl/ls/Sicilianos_HR.html)”
+    Ahead](https://legal.un.org/avl/ls/Sicilianos_HR.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (43 mins.).  
@@ -121,7 +124,7 @@ Upon successful completion of this unit, the student will be able to:
     Feride Acar’s “[The General Framework and the Monitoring Mechanism
     of the Convention on the Elimination of All Forms of Discrimination
     Against
-    Women](https://web.archive.org/web/20131109213021/http://untreaty.un.org/cod/avl/ls/Acar_HR.html)”
+    Women](https://legal.un.org/avl/ls/Acar_HR.html)”
     (RealPlayer Video)  
         
      Instructions: Please watch the video presentation (49 mins.).  


### PR DESCRIPTION
UN Library links didn't work because the video doesn't work on Web Archive,  PDFs on Web Archive *do* work
Updated all links, that were able to be updated anyway.  Saylor Handbook was updated.  I believe all links or almost all links
were updated very carefully, hand done to make sure they were correct.  Viewing live markdown showed that markdown was 
displayed wrong on ReText application on Ubuntu 22.04, so I fixed markdown as required to show properly on ReText live preview.